### PR TITLE
JOUR-15 - urls are now constructed safely to account for trailing slash

### DIFF
--- a/client/static/main.js
+++ b/client/static/main.js
@@ -353,9 +353,9 @@ function handleAddressInput(address, suggestionsContainer) {
  * asynchronous operations and calls the renderSuggestions method.
  */
 async function getAddressSuggestions(address, suggestionsContainer) {
-    const currentUrl = window.location.href;
-    const targetUrl = currentUrl + '/get-address-suggestions'
-    const res = await fetch(targetUrl, {
+    const url = new URL(window.location.href);
+    url.pathname += url.pathname.endsWith('/') ? 'get-address-suggestions' : '/get-address-suggestions';
+    const res = await fetch(url.toString(), {
         method: 'POST',
         headers: {
             'content-type': 'application/json'
@@ -370,7 +370,7 @@ async function getAddressSuggestions(address, suggestionsContainer) {
             const error = await res.json()
             console.log(error)
         } catch {
-            console.log(res.text)
+            console.log(res.text())
 
         }
     }


### PR DESCRIPTION
## JIRA Task Title And Link
[Custom domain](https://ideapartners.atlassian.net/browse/JOUR-15)

## Description of the PR
As part of migrating to a custom domain for our api gateway, we encountered errors with the server url. Turns out it was appending an extra trailing slash after the root.

## Solution Description
We now construct the url using the URL constructor and check for the trailing slash before constructing the rest.

## Tests
N/A

## Manual Testing
Yes tested locally and on ourtrip.app
