### PR TITLE
( JOUR-12, JOUR-14 ) - map now follows the line animation and zooms automatically

### DIFF
--- a/client/static/utilities.js
+++ b/client/static/utilities.js
@@ -1,0 +1,9 @@
+/**
+ * This function is a utility that delays execution for a given number of milliseconds.
+ *
+ * @param {number} ms - The duration in milliseconds for which the function should pause execution.
+ * @returns {Promise} A promise that resolves after the specified duration.
+ */
+export function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## JIRA Task Title And Link
[Follow line with zoom level](https://ideapartners.atlassian.net/browse/JOUR-12)
[Zoom out at the end ](https://ideapartners.atlassian.net/browse/JOUR-14)

## Description of the PR
We want the map to follow the journey of the line and then zoom out to show all the points

## Solution Description
- We pull the view out to it's own object that's passed into the map
- We removed the animatePoints function since we have the coordinates in the line and can render there. 
- We calculate the appropriate zoom level between the starting point and the next point
- We zoom in and then we animate the map view to follow the line as it is drawn.
- We zoom out at the very end to the bounding box that contains all of our points.

## Tests
Still explorations, no testing.

## Manual Testing
Yes Tested locally and at https://ourtrip.app
