### PR TITLE
JOUR-20 - photos are stored in filemap and accessible on submit

### DIFF
--- a/client/static/main.js
+++ b/client/static/main.js
@@ -1,5 +1,6 @@
 import './style.css';
-import {createLine, exitFullscreen, requestFullscreen, setMapSource, animateLine, map} from './map.js';
+import { createLine, exitFullscreen, requestFullscreen, setMapSource, animateLine, map } from './map.js';
+import { resizeImage, createPolaroid } from './media.js';
 
 const locations = document.querySelector('.locations');
 const add = document.querySelector('.add');
@@ -29,7 +30,7 @@ submit.onclick = async () => {
 
     // Add the line layer to the map
     map.addLayer(lineVectorLayer);
-    animateLine(lineString, lineFeature, allCoordinates)
+    animateLine(lineString, lineFeature, locationData)
 }
 
 mapClose.onclick = (event) => {
@@ -142,6 +143,8 @@ function handleAddressInput(address, suggestionsContainer) {
     }
 }
 
+
+
 function handleImagesInput(fileInput, imagesContainer, imageCountWarning) {
     const files = fileInput.files;
     // We only let 3 images in now, so check for how many we've uploaded
@@ -160,35 +163,11 @@ function handleImagesInput(fileInput, imagesContainer, imageCountWarning) {
         reader.onload = function (e) {
             const img = new Image();
             img.onload = function () {
-                // Determine the scale factor and cropping dimensions
-                const scale = 85 / Math.min(img.width, img.height);
-                const scaledWidth = img.width * scale;
-                const scaledHeight = img.height * scale;
-                const dx = (scaledWidth - 85) / 2;
-                const dy = (scaledHeight - 85) / 2;
 
-                // Create a canvas to resize and crop the image
-                const canvas = document.createElement('canvas');
-                const ctx = canvas.getContext('2d');
-                canvas.width = canvas.height = 85; // Target dimensions
+                const src = resizeImage(img, 85);
+                const photoContainer = createPolaroid(src);
 
-                // Draw the image onto the canvas with scaling and center cropping
-                ctx.drawImage(img, -dx, -dy, scaledWidth, scaledHeight);
-
-                // Convert canvas to an image for preview
-                const src = canvas.toDataURL('image/jpeg');
-
-                // Display the thumbnail
-                const thumbnail = new Image();
-                thumbnail.src = src;
-
-                // Assuming this part is inside your image onload function
-                const photoContainer = document.createElement('div');
-                photoContainer.className = 'photo';
                 photoContainer.setAttribute('file-name', file.name)
-
-                // Assuming 'thumbnail' is your image element
-                photoContainer.appendChild(thumbnail);
 
                 const closeIcon = document.createElement('span');
                 closeIcon.innerHTML = '&times;'; // Using HTML entity for simplicity

--- a/client/static/main.js
+++ b/client/static/main.js
@@ -144,7 +144,17 @@ function handleAddressInput(address, suggestionsContainer) {
 }
 
 
-
+/**
+ * Processes input files for image upload, limiting to 3, with warnings.
+ *
+ * Manages image file input, enforcing a maximum of 3 images. Displays a
+ * warning if the limit is exceeded. Newly selected images not already
+ * present are read and processed for display.
+ *
+ * @param {HTMLElement} fileInput - Input element for files.
+ * @param {HTMLElement} imagesContainer - Container for image thumbnails.
+ * @param {HTMLElement} imageCountWarning - Element to display limit warnings.
+ */
 function handleImagesInput(fileInput, imagesContainer, imageCountWarning) {
     const files = fileInput.files;
     // We only let 3 images in now, so check for how many we've uploaded
@@ -162,22 +172,7 @@ function handleImagesInput(fileInput, imagesContainer, imageCountWarning) {
         const reader = new FileReader();
         reader.onload = function (e) {
             const img = new Image();
-            img.onload = function () {
-
-                const src = resizeImage(img, 85);
-                const photoContainer = createPolaroid(src);
-
-                photoContainer.setAttribute('file-name', file.name)
-
-                const closeIcon = document.createElement('span');
-                closeIcon.innerHTML = '&times;'; // Using HTML entity for simplicity
-                closeIcon.className = 'close';
-                photoContainer.appendChild(closeIcon);
-
-                closeIcon.onclick = () => removeImage(file.name, imagesContainer) ;
-
-                imagesContainer.appendChild(photoContainer);
-            };
+            img.onload = () => handleThumbnailLoad(img, file.name, imagesContainer);
             img.src = e.target.result;
             photoFileMap[file.name] = e.target.result;
         };
@@ -185,6 +180,40 @@ function handleImagesInput(fileInput, imagesContainer, imageCountWarning) {
     });
 }
 
+/**
+ * Loads a thumbnail into the container with a removal option.
+ *
+ * Resizes an image, wraps it in a polaroid style, and appends a close icon
+ * for removal. Sets up an onclick handler for the icon to remove the image.
+ *
+ * @param {HTMLImageElement} img - Image to be processed.
+ * @param {string} fileName - Name of the file for identification.
+ * @param {HTMLElement} imagesContainer - Container for the thumbnails.
+ */
+function handleThumbnailLoad(img, fileName, imagesContainer) {
+    const src = resizeImage(img, 85);
+    const photoContainer = createPolaroid(src);
+
+    photoContainer.setAttribute('file-name', fileName)
+
+    const closeIcon = document.createElement('span');
+    closeIcon.innerHTML = '&times;'; // Using HTML entity for simplicity
+    closeIcon.className = 'close';
+    photoContainer.appendChild(closeIcon);
+
+    closeIcon.onclick = () => removeImage(fileName, imagesContainer);
+    imagesContainer.appendChild(photoContainer);
+}
+
+/**
+ * Removes an image element from the container by filename.
+ *
+ * Locates an image within the imagesContainer using the filename as a selector
+ * attribute and removes it if found.
+ *
+ * @param {string} filename - The name of the file to identify the image.
+ * @param {HTMLElement} imagesContainer - The container from which to remove.
+ */
 function removeImage(filename, imagesContainer) {
     let selector = `[file-name="${filename}"]`; // Construct the attribute selector
     let element = imagesContainer.querySelector(selector);

--- a/client/static/main.js
+++ b/client/static/main.js
@@ -8,6 +8,7 @@ const main = document.querySelector(".main");
 const mapClose = document.querySelector('.close');
 let addressTimeoutId = null;
 
+const photoFileMap = {};
 
 // Event listener for the map styles dropdown
 document.getElementById('mapSource').addEventListener('change', function () {
@@ -56,8 +57,12 @@ function getLocationFormData() {
         const departure = location.querySelector('input[name=departure]').value;
         const id = addressElem.id;
         const coordinates = addressElem.getAttribute('data-coordinates');
+        const imagesContainer = location.querySelector('.images-container');
+        const existingFiles = Array.from(imagesContainer.children).map(el => el.getAttribute('file-name'));
+        const images = existingFiles.map(file => photoFileMap[file]);
 
-        data.push({ id, address, arrival, departure, coordinates });
+
+        data.push({ id, address, arrival, departure, coordinates, images });
     }
     return data;
 }
@@ -139,6 +144,7 @@ function handleAddressInput(address, suggestionsContainer) {
 
 function handleImagesInput(fileInput, imagesContainer, imageCountWarning) {
     const files = fileInput.files;
+    // We only let 3 images in now, so check for how many we've uploaded
     if (imagesContainer.children.length + files.length > 3) {
         imageCountWarning.style.display = 'block';
         return;
@@ -146,6 +152,7 @@ function handleImagesInput(fileInput, imagesContainer, imageCountWarning) {
         imageCountWarning.style.display = 'none';
     }
 
+    // If less than 3, we will add the new images to the array.
     const existingFiles = Array.from(imagesContainer.children).map(el => el.getAttribute('file-name'));
     Array.from(files).forEach(file => {
         if (existingFiles.includes(file.name)) return;
@@ -193,6 +200,7 @@ function handleImagesInput(fileInput, imagesContainer, imageCountWarning) {
                 imagesContainer.appendChild(photoContainer);
             };
             img.src = e.target.result;
+            photoFileMap[file.name] = e.target.result;
         };
         reader.readAsDataURL(file);
     });

--- a/client/static/media.js
+++ b/client/static/media.js
@@ -1,3 +1,16 @@
+/**
+ * Resizes an image to fit within a square of maxDimension, maintaining aspect ratio.
+ *
+ * @param {HTMLImageElement} img - The image to be resized.
+ * @param {number} maxDimension - The maximum width and height of the resized image.
+ * Defaults to 85 pixels.
+ *
+ * This function resizes an image, ensuring it fits within a specified maximum
+ * dimension square, maintaining its aspect ratio. It uses a canvas to scale
+ * and optionally crop the image, then returns the result as a data URL.
+ *
+ * @returns {string} A data URL representing the resized image in JPEG format.
+ */
 function resizeImage(img, maxDimension = 85) {
     // Determine the scale factor and cropping dimensions
     const scale = maxDimension / Math.min(img.width, img.height);
@@ -18,6 +31,18 @@ function resizeImage(img, maxDimension = 85) {
     return canvas.toDataURL('image/jpeg');
 }
 
+/**
+ * Creates a polaroid-style HTML element for a given image source.
+ *
+ * @param {string} imgSrc - The source URL of the image to be wrapped in a
+ * polaroid-style container.
+ *
+ * This function generates an HTMLImageElement with the specified `imgSrc`
+ * and wraps it in a div with a class name 'photo', mimicking a polaroid
+ * effect.
+ *
+ * @returns {HTMLElement} The polaroid-style photo container element.
+ */
 function createPolaroid(imgSrc) {
     const image = new Image();
     image.src = imgSrc;

--- a/client/static/media.js
+++ b/client/static/media.js
@@ -1,0 +1,35 @@
+function resizeImage(img, maxDimension = 85) {
+    // Determine the scale factor and cropping dimensions
+    const scale = maxDimension / Math.min(img.width, img.height);
+    const scaledWidth = img.width * scale;
+    const scaledHeight = img.height * scale;
+    const dx = (scaledWidth - maxDimension) / 2;
+    const dy = (scaledHeight - maxDimension) / 2;
+
+    // Create a canvas to resize and crop the image
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    canvas.width = canvas.height = maxDimension; // Target dimensions
+
+    // Draw the image onto the canvas with scaling and center cropping
+    ctx.drawImage(img, -dx, -dy, scaledWidth, scaledHeight);
+
+    // Convert canvas to an image for preview
+    return canvas.toDataURL('image/jpeg');
+}
+
+function createPolaroid(imgSrc) {
+    const image = new Image();
+    image.src = imgSrc;
+
+    const photoContainer = document.createElement('div');
+    photoContainer.appendChild(image);
+    photoContainer.className = 'photo';
+    return photoContainer;
+}
+
+
+export {
+    createPolaroid,
+    resizeImage
+}


### PR DESCRIPTION
## JIRA Task Title And Link
[Render photos during pauses](https://ideapartners.atlassian.net/browse/JOUR-20)

## Description of the PR
We want to show photos as we are pausing at each individual city.

## Solution Description
- When we create the thumbnail, we now also store the loaded image in the filemap object. When we submit, we pull the image from that object to be able to pass it into the map functions. There is a risk that someone would then decide not to use that image and we would still be storing it in memory. But I think if we are also removing images after we have loaded things into the dom and done the animation, then it might not be such a bad thing. 
- Images are added to the map in a cross pattern around the location (currently not well situated). The images are rendered as polaroids and we are just using the point coordinates as the base and specifying an offset. This means that the images are staying exactly where they are across zoom levels, just like we can still see the icon of the place regardless of zoom level. Currently the images are not looking too great and don't have any animations or fade, and they are not being removed, cluttering the map. 

## Tests
Still exploring

## Manual Testing
Verified locally. 
